### PR TITLE
Place Typst's label at the beginning of start_of_file nodes

### DIFF
--- a/src/atsphinx/typst/writer.py
+++ b/src/atsphinx/typst/writer.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 from docutils import nodes
 from rst2typst.writer import TypstTranslator as BaseTypstTranslator
+from sphinx import addnodes
 from sphinx.util.docutils import SphinxTranslator
 from sphinx.util.logging import getLogger
 
@@ -39,7 +40,6 @@ class TypstTranslator(SphinxTranslator, BaseTypstTranslator):
         "index",
         "legend",
         "pending_xref",
-        "start_of_file",
         "todo_node",
     ]
 
@@ -81,3 +81,12 @@ class TypstTranslator(SphinxTranslator, BaseTypstTranslator):
         self.builder.images.setdefault(uri_path, uri_dest)
         node["uri"] = uri_map
         super().visit_image(node)
+
+    # Implements for Sphinx's nodes
+    # =============================
+    def visit_start_of_file(self, node: addnodes.start_of_file):
+        label = node["docname"].replace("/", ":")
+        self.body.append(f"\n<docname::{label}>\n")
+
+    def depart_start_of_file(self, node: addnodes.start_of_file):
+        pass

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from sphinx.testing.util import SphinxTestApp
+
+
+class Test_TypstTranslator:  # noqa: D101
+    @pytest.mark.sphinx("typst", testroot="toctree")
+    def test__start_of_file(self, app: SphinxTestApp):  # noqa: D102
+        app.build()
+        out = (app.outdir / "index.typ").read_text()
+        assert "<docname::section-1>" in out
+        assert "<docname::section-1-1>" in out


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of document file boundaries in Typst output generation to ensure proper structure markers are correctly included in generated documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->