### PR TITLE
Add link to download PDF generated by `typstpdf` build

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -35,7 +35,7 @@ jobs:
           uv sync --all-extras --frozen
       - name: 'Build document'
         run: |
-          task --yes setup docs:build-mini18n-dirhtml
+          task --yes setup docs-pages
       - name: 'Upload artifact'
         uses: actions/upload-pages-artifact@v5
         with:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -55,3 +55,11 @@ tasks:
         --implicit-namespaces
         --output-dir=api/
         ../src/atsphinx
+  docs-pages:
+    desc: 'Build all assets for GitHub Pages'
+    cmds:
+      - task: 'docs:build-typstpdf'
+      - task: 'docs:build-mini18n-dirhtml'
+      - |
+        mkdir -p docs/_build/mini18n-dirhtml/_pdf/
+        cp docs/_build/typstpdf/document.pdf docs/_build/mini18n-dirhtml/_pdf/

--- a/docs/_templates/.gitignore
+++ b/docs/_templates/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/docs/_templates/pdf-link.html
+++ b/docs/_templates/pdf-link.html
@@ -1,0 +1,11 @@
+<div id="atsphinx-typst-download-pdf">
+  <style>
+    div#atsphinx-typst-download-pdf div {
+      text-align: center;
+      padding: var(--sidebar-item-spacing-vertical) var(--sidebar-item-spacing-horizontal);
+    }
+  </style>
+  <div>
+    <a href="{{ pdf_url }}" target="_blank">Download PDF</a>
+  </div>
+</div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,11 +121,10 @@ def setup(app: Sphinx):
     def _bind_pdf_url(
         app: Sphinx,
         pagename: str,
-        tmplatename: str,
+        templatename: str,
         context: dict[str, Any],
         doctree: nodes.document | None,
     ):
         context["pdf_url"] = f"{mini18n_basepath}/_pdf/document.pdf"
 
     app.connect("html-page-context", _bind_pdf_url)
-    pass

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,15 @@
+from typing import TYPE_CHECKING
+
 from atsphinx.mini18n import get_template_dir as get_mini18n_template_dir
 
 from atsphinx.typst import __version__ as version
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from docutils import nodes
+    from sphinx.application import Sphinx
+
 
 # -- Project information
 project = "atsphinx-typst"
@@ -58,6 +67,7 @@ html_sidebars = {
         "sidebar/scroll-start.html",
         "sidebar/brand.html",
         "mini18n/snippets/select-lang.html",
+        "pdf-link.html",
         "sidebar/search.html",
         "sidebar/navigation.html",
         "sidebar/ethical-ads.html",
@@ -105,3 +115,17 @@ todo_include_todos = True
 mini18n_default_language = "en"
 mini18n_support_languages = ["en", "ja"]
 mini18n_basepath = "/typst/"
+
+
+def setup(app: Sphinx):
+    def _bind_pdf_url(
+        app: Sphinx,
+        pagename: str,
+        tmplatename: str,
+        context: dict[str, Any],
+        doctree: nodes.document | None,
+    ):
+        context["pdf_url"] = f"{mini18n_basepath}/_pdf/document.pdf"
+
+    app.connect("html-page-context", _bind_pdf_url)
+    pass

--- a/src/atsphinx/typst/writer.py
+++ b/src/atsphinx/typst/writer.py
@@ -100,11 +100,13 @@ class TypstTranslator(SphinxTranslator, BaseTypstTranslator):
 
     def visit_reference(self, node):
         # NOTE: It may be should implement in rst2typst.
-        if node.get("internal", False):
+        if not node.get("internal", False):
+            return super().visit_reference(node)
+        if "refuri" in node:
             uri = node["refuri"][1:]
-            self.body.append(f"#link(<{uri}>)[")
-            return
-        super().visit_reference(node)
+        if "refid" in node:
+            uri = node["refid"]
+        return self.body.append(f"#link(<{uri}>)[")
 
     # Implements for Sphinx's nodes
     # =============================

--- a/src/atsphinx/typst/writer.py
+++ b/src/atsphinx/typst/writer.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 from docutils import nodes
 from rst2typst.writer import TypstTranslator as BaseTypstTranslator
 from sphinx import addnodes
+from sphinx.errors import ExtensionError
 from sphinx.util.docutils import SphinxTranslator
 from sphinx.util.index_entries import split_index_msg
 from sphinx.util.logging import getLogger
@@ -104,8 +105,10 @@ class TypstTranslator(SphinxTranslator, BaseTypstTranslator):
             return super().visit_reference(node)
         if "refuri" in node:
             uri = node["refuri"][1:]
-        if "refid" in node:
+        elif "refid" in node:
             uri = node["refid"]
+        else:
+            raise ExtensionError("<reference> requires 'refuri' or 'refid' attribute")
         return self.body.append(f"#link(<{uri}>)[")
 
     # Implements for Sphinx's nodes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visible "Download PDF" link on documentation pages.

* **Documentation**
  * Enhanced the docs build to produce and include PDF output for pages.
  * Updated templates to ensure the PDF link is shown.

* **Bug Fixes**
  * Improved internal reference handling in the generated output so document links resolve more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->