### PR TITLE
feat: add custom theme directory support with typst_themes_path config

### DIFF
--- a/src/atsphinx/typst/builders.py
+++ b/src/atsphinx/typst/builders.py
@@ -49,6 +49,11 @@ class TypstBuilder(Builder):
         return "all targets"
 
     def prepare_writing(self, docnames: set[str]) -> None:  # noqa: D102
+        """
+           Preload themes to copy assets before write_documents.
+           args:
+            docnames: set[str] unused parameter
+        """
         # Preload themes to copy assets before write_documents.
         def _load_theme(name: str) -> theming.Theme | None:
             if name in self._themes:

--- a/src/atsphinx/typst/builders.py
+++ b/src/atsphinx/typst/builders.py
@@ -54,7 +54,9 @@ class TypstBuilder(Builder):
             if name in self._themes:
                 return
 
-            theme = theming.load_theme(name)
+            theme = theming.load_theme(
+                name, typst_themes_path=self.config.typst_themes_path
+            )
             theme.init(self)
             self._themes[name] = theme
             parent = theme.get_parent_theme()

--- a/src/atsphinx/typst/config.py
+++ b/src/atsphinx/typst/config.py
@@ -82,7 +82,12 @@ def compute_configurations(app: Sphinx, config: Config):
     config.typst_themes_path = typst_themes_path
 
 
-def setup(app: Sphinx):  # noqa: D103
+def setup(app: Sphinx):
+    """Register configuration values and connect event handlers.
+
+    Args:
+        app: Sphinx application instance
+    """
     app.add_config_value("typst_documents", [], "env", list[dict])
     app.add_config_value("typst_static_path", [], "env", [list[str | Path]])
     app.add_config_value("typst_themes_path", [], "env", [list[str | Path]])

--- a/src/atsphinx/typst/config.py
+++ b/src/atsphinx/typst/config.py
@@ -56,7 +56,7 @@ def compute_configurations(app: Sphinx, config: Config):
                 "filename": f"document-{config.language}",
                 "title": f"{config.project} Documentation [{config.language.upper()}]",
                 "author": config.author,
-                "theme": "manual",
+                "theme": config.theme,
             }
         )
     for idx, user_value in enumerate(document_settings):
@@ -72,9 +72,19 @@ def compute_configurations(app: Sphinx, config: Config):
         typst_static_path.append(app.confdir / p)
     config.typst_static_path = typst_static_path
 
+    # 3. Cast string path to Path object and register custom theme directories.
+    typst_themes_path = []
+    for p in config.typst_themes_path:
+        if isinstance(p, Path):
+            typst_themes_path.append(p)
+        else:
+            typst_themes_path.append(app.confdir / p)
+    config.typst_themes_path = typst_themes_path
+
 
 def setup(app: Sphinx):  # noqa: D103
     app.add_config_value("typst_documents", [], "env", list[dict])
     app.add_config_value("typst_static_path", [], "env", [list[str | Path]])
+    app.add_config_value("typst_themes_path", [], "env", [list[str | Path]])
     app.add_config_value("typst_font_paths", [], "env", [list[str | Path]])
     app.connect("config-inited", compute_configurations)

--- a/src/atsphinx/typst/config.py
+++ b/src/atsphinx/typst/config.py
@@ -63,20 +63,20 @@ def compute_configurations(app: Sphinx, config: Config):
         document_settings[idx] = DEFAULT_DOCUMENT_SETTINGS | user_value
     config.typst_documents = document_settings
 
-    # 2. Cast string path to Path object.
+    # 2. Cast string path to Path object for static_paths
     typst_static_path = []
     for p in config.typst_static_path:
         if isinstance(p, Path):
-            typst_static_path.append(p)
+            typst_static_path.append(p if p.is_absolute() else app.confdir / p)
             continue
         typst_static_path.append(app.confdir / p)
     config.typst_static_path = typst_static_path
 
-    # 3. Cast string path to Path object and register custom theme directories.
+    # 3. Cast string path to Path object for themes_paths
     typst_themes_path = []
     for p in config.typst_themes_path:
         if isinstance(p, Path):
-            typst_themes_path.append(p)
+            typst_themes_path.append(p if p.is_absolute() else app.confdir / p)
         else:
             typst_themes_path.append(app.confdir / p)
     config.typst_themes_path = typst_themes_path

--- a/src/atsphinx/typst/theming.py
+++ b/src/atsphinx/typst/theming.py
@@ -164,6 +164,7 @@ def load_theme(name: str, typst_themes_path: list[Path] = []) -> Theme:
 
     def _find_theme_path(name: str) -> Path:
         """Search theme path in order to rules.
+        Searches custom theme directories first, then built-in themes.
 
         When it does not found, it raises ThemeError.
         """

--- a/src/atsphinx/typst/theming.py
+++ b/src/atsphinx/typst/theming.py
@@ -152,7 +152,7 @@ def _verify_theme_path(theme_dir: Path) -> bool:
     )
 
 
-def load_theme(name: str) -> Theme:
+def load_theme(name: str, typst_themes_path: list[Path] = []) -> Theme:
     """Find theme directory and load as theme object.
 
     If it is not found, raise error.
@@ -167,6 +167,12 @@ def load_theme(name: str) -> Theme:
 
         When it does not found, it raises ThemeError.
         """
+        # Search from custom theme directories first
+        for custom_dir in typst_themes_path:
+            theme_dir = custom_dir / name
+            if _verify_theme_path(theme_dir):
+                return theme_dir
+
         # Search from built-in themes
         theme_dir = _BASE_THEMES_DIR / name
         if _verify_theme_path(theme_dir):


### PR DESCRIPTION
## How to use

```python
typst_documents = [{
  "title": "project",
  "theme": "my_theme",
}]

typst_static_path = ["_static"]
# this is new
typst_themes_path = ["_themes"]
```
and then have `_themes/my_theme/theme.toml` available (see `src/atsphinx/typst/themes/manual` for reference)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom Typst theme paths, enabling users to specify custom directories where themes are located. Custom themes are now searched before built-in themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->