### PR TITLE
Display typst compile errors to the user in a friendly way

### DIFF
--- a/src/atsphinx/typst/builders.py
+++ b/src/atsphinx/typst/builders.py
@@ -75,9 +75,9 @@ class TypstBuilder(Builder):
         visitor: writer.TypstTranslator = self.create_translator(doctree, self)  # type: ignore[assignment]
         doctree.walkabout(visitor)
         context = theming.ThemeContext(
-            project=self.app.config.project,
-            release=self.app.config.release,
-            copyright=self.app.config.copyright,
+            project=self.config.project,
+            release=self.config.release,
+            copyright=self.config.copyright,
             # TODO: Support user custm format.
             build_date=self._build_date.strftime("%Y-%m-%d"),
             title=document_settings["title"],
@@ -88,7 +88,7 @@ class TypstBuilder(Builder):
             packages=visitor.packages,
             translated=visitor.context,
         )
-        out = Path(self.app.outdir) / f"{document_settings['filename']}.typ"
+        out = Path(self.outdir) / f"{document_settings['filename']}.typ"
         theme.write_doc(out, context)
 
     def assemble_doctree(
@@ -122,7 +122,7 @@ class TypstBuilder(Builder):
     def copy_assets(self):  # noqa: D102
         # Copying all theme assets.
         def _copy_theme_assets():
-            base_dir = self.app.outdir / "_themes"
+            base_dir = self.outdir / "_themes"
             for name, theme in self._themes.items():
                 assets_outdir = base_dir / name
                 assets_srcdir = theme.get_theme_dir() / "assets"
@@ -178,6 +178,6 @@ class TypstPDFBuilder(TypstBuilder):
         if self.config.typst_font_paths:
             kwargs["font_paths"] = self.config.typst_font_paths
         for document_settings in self.config.typst_documents:
-            src = Path(self.app.outdir) / f"{document_settings['filename']}.typ"
-            out = Path(self.app.outdir) / f"{document_settings['filename']}.pdf"
+            src = Path(self.outdir) / f"{document_settings['filename']}.typ"
+            out = Path(self.outdir) / f"{document_settings['filename']}.pdf"
             typst.compile(src, output=out, **kwargs)

--- a/src/atsphinx/typst/builders.py
+++ b/src/atsphinx/typst/builders.py
@@ -180,4 +180,7 @@ class TypstPDFBuilder(TypstBuilder):
         for document_settings in self.config.typst_documents:
             src = Path(self.outdir) / f"{document_settings['filename']}.typ"
             out = Path(self.outdir) / f"{document_settings['filename']}.pdf"
-            typst.compile(src, output=out, **kwargs)
+            try:
+                typst.compile(src, output=out, **kwargs)
+            except typst.TypstError as e:
+                raise SphinxError(f"Typst compilation failed for {str(src)!r}: {e.diagnostic}") from e

--- a/src/atsphinx/typst/writer.py
+++ b/src/atsphinx/typst/writer.py
@@ -92,7 +92,7 @@ class TypstTranslator(SphinxTranslator, BaseTypstTranslator):
         source = Path(self.document["source"])
         uri_path = source.parent / uri
         uri_dest = self.builder._images_dir / uri_path.relative_to(
-            self.builder.app.srcdir
+            self.builder.srcdir
         )
         uri_map = uri_dest.relative_to(self.builder.outdir)
         self.builder.images.setdefault(uri_path, uri_dest)

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -80,3 +80,15 @@ class Test_TypstPDFBuilder:
             app.build()
             assert (app.outdir / "index.typ").exists()
             assert (app.outdir / "index.pdf").exists()
+
+    class Test_compile_error:
+        @pytest.mark.sphinx("typstpdf", testroot="typst-compile-error")
+        def test__typst_compile_error_handling(self, app: SphinxTestApp):
+            """Test that TypstError is caught and rethrown with diagnostics."""
+            from sphinx.errors import SphinxError
+
+            with pytest.raises(SphinxError, match="unclosed delimiter"):
+                app.build()
+
+            # Verify PDF was not created due to compilation failure.
+            assert not (app.outdir / "index.pdf").exists()

--- a/tests/testdocs/test-typst-compile-error/conf.py
+++ b/tests/testdocs/test-typst-compile-error/conf.py
@@ -1,0 +1,14 @@
+# noqa: D100
+
+extensions = [
+    "atsphinx.typst",
+]
+
+typst_documents = [
+    {
+        "entrypoint": "index",
+        "filename": "index",
+        "theme": "manual",
+        "title": "Test documentation with compile error",
+    }
+]

--- a/tests/testdocs/test-typst-compile-error/index.rst
+++ b/tests/testdocs/test-typst-compile-error/index.rst
@@ -1,0 +1,8 @@
+Test doc with Typst compile error
+==================================
+
+This document contains invalid Typst syntax that will cause a compile error.
+
+.. raw:: typst
+
+   #let unclosed = [


### PR DESCRIPTION
Typst can throw an compile error if the input was malformed. Currently,
`typst.compile()` raises a TypstError exception that bubbles up to
Sphinx, which then displays a stacktrace. Unfortunately, this stacktrace
does not contain information about the typst code that actually failed
to compile.

Capture the exception, and rethrow it with the right information
included. For example, the unit test gives the following output:

```
E               sphinx.errors.SphinxError: Typst compilation failed for '/tmp/pytest-of-philipp/pytest-19/typst-compile-error/_build/typstpdf/index.typ': error: unclosed delimiter
E                   ┌─ ../../../../tmp/pytest-of-philipp/pytest-19/typst-compile-error/_build/typstpdf/index.typ:169:16
E                   │
E               169 │ #let unclosed = [
E                   │                 ^
```


Additionally, this PR resolves deprecation warnings that were introduced in Sphinx 9. I included these changes as a separate commit in this PR because the changes conflict otherwise. If you prefer to have two PRs let me know and I'll resolve the merge conflicts after the first PR goes in.


- **Do not use deprecated Builder.app member**
- **Display typst compile errors to the user in a friendly way**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected configuration and output path handling in Typst builders to use appropriate sources
  * Fixed image path resolution during Typst translation

* **Improvements**
  * Enhanced Typst compilation error reporting with detailed diagnostic messages

* **Tests**
  * Added test coverage for Typst compilation error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->