### PR TITLE
Add support for cross-document references

### DIFF
--- a/src/atsphinx/typst/builders.py
+++ b/src/atsphinx/typst/builders.py
@@ -12,7 +12,7 @@ from rst2typst.package import package_dir as rst2typst_package_dir
 from sphinx import addnodes
 from sphinx._cli.util.colour import darkgreen
 from sphinx.builders import Builder
-from sphinx.errors import SphinxError
+from sphinx.errors import NoUri, SphinxError
 from sphinx.util.fileutil import copy_asset, copy_asset_file
 from sphinx.util.nodes import inline_all_toctrees
 
@@ -40,6 +40,10 @@ class TypstBuilder(Builder):
         self._static_dir = Path(self.outdir / "_static")
         self._images_dir = Path(self.outdir / "_images")
         self._build_date = date.today()
+        # Docnames merged into the document currently being written, like
+        # the LaTeX builder's ``self.docnames``. Populated by
+        # ``assemble_doctree()`` before it resolves references.
+        self.docnames: set[str] = set()
 
     def init(self):  # noqa: D102
         super().init()
@@ -111,13 +115,29 @@ class TypstBuilder(Builder):
                 root_section += toctree
             root = root.copy()
             root += root_section
-        tree = inline_all_toctrees(self, {docname}, docname, root, darkgreen, [docname])
+        self.docnames = {docname}
+        tree = inline_all_toctrees(
+            self, self.docnames, docname, root, darkgreen, [docname]
+        )
+        tree["docname"] = docname
+        # Like the LaTeX builder, resolve references right after merging so
+        # that Sphinx's own domains (:doc:, :ref:, :confval:, intersphinx,
+        # ...) do the resolution; see get_target_uri()/get_relative_uri()
+        # for how that maps onto the single merged Typst document.
         self.env.resolve_references(tree, docname, self)
         return tree
 
     def get_target_uri(self, docname, typ=None):  # noqa: D102
-        # TODO: Implement it!
-        return ""
+        if docname not in self.docnames:
+            raise NoUri(docname, typ)
+        # All documents are merged into one, so the docname itself is
+        # enough; the writer turns it into the appropriate Typst label.
+        return docname
+
+    def get_relative_uri(self, from_, to, typ=None):  # noqa: D102
+        # Ignore source path: there's only one output file, so there is no
+        # relative path to compute (cf. the LaTeX builder).
+        return self.get_target_uri(to, typ)
 
     def copy_assets(self):  # noqa: D102
         # Copying all theme assets.

--- a/src/atsphinx/typst/writer.py
+++ b/src/atsphinx/typst/writer.py
@@ -38,6 +38,12 @@ def _typst_local_package_fullname(name: str, version: str | None = None) -> str:
     return f"@local/{name}:{version}"
 
 
+def _doc_label(docname: str) -> str:
+    # Merged into one Typst file, so labels need a per-document namespace
+    # to avoid id collisions (e.g. two "Installation" sections).
+    return docname.replace("/", ":")
+
+
 class TypstTranslator(SphinxTranslator, BaseTypstTranslator):
     """Custom translator that has converter from dotctree to Typst syntax."""
 
@@ -65,14 +71,43 @@ class TypstTranslator(SphinxTranslator, BaseTypstTranslator):
         self.context = {
             "has_index": False,
         }
+        # Current document, for namespacing labels (like LaTeX's curfilestack).
+        self.curfilestack = [document["docname"]]
 
     # ------
     # visit/departuer methods
     # ------
+    def visit_document(self, node: nodes.document):
+        super().visit_document(node)
+        self._write_anchor(_doc_label(self.curfilestack[-1]))
+
     def visit_title(self, node: nodes.title):
         if isinstance(node.parent, nodes.section) and self._section_level < 1:
             raise nodes.SkipNode
+
+        # ids[0] (the heading's own slug) is anchored inline in depart_title;
+        # ids[1:] (explicit labels above the heading) anchor here, before
+        # the heading, so a :ref: lands at the section's top.
+        if isinstance(node.parent, nodes.section):
+            docname = _doc_label(self.curfilestack[-1])
+            for node_id in node.parent.get("ids", [])[1:]:
+                self._write_anchor(f"{docname}:{node_id}")
+
         super().visit_title(node)
+
+    def depart_title(self, node: nodes.title):
+        """Add a label to section titles for cross-referencing."""
+        docname = _doc_label(self.curfilestack[-1])
+        if isinstance(node.parent, nodes.section):
+            ids = node.parent.get("ids", [])
+        else:
+            ids = []
+
+        if ids:
+            # Label goes after the title text, before the newline: == Title <label>
+            self.body.append(f" <{docname}:{ids[0]}>")
+
+        super().depart_title(node)
 
     # TODO: It should separate transform and translate.
     def visit_container(self, node: nodes.container):
@@ -99,20 +134,68 @@ class TypstTranslator(SphinxTranslator, BaseTypstTranslator):
         node["uri"] = uri_map
         super().visit_image(node)
 
-    def visit_reference(self, node):
+    def visit_reference(self, node: nodes.reference):
         # NOTE: It may be should implement in rst2typst.
-        if not node.get("internal", False):
-            return super().visit_reference(node)
-        if "refuri" in node:
-            uri = node["refuri"][1:]
-        elif "refid" in node:
-            uri = node["refid"]
+        # Key off refid/refuri directly (like Sphinx's LaTeX writer), not
+        # ``internal``: plain anchor refs (RST `Title`_, MyST #anchor) get
+        # refid without Sphinx ever setting ``internal``.
+        if "refid" in node:
+            uri = f"{_doc_label(self.curfilestack[-1])}:{node['refid']}"
+        elif node.get("internal", False):
+            # Sphinx-resolved cross-doc reference, shaped "docname" or
+            # "docname#labelid".
+            if "refuri" not in node:
+                raise ExtensionError(
+                    "<reference> requires 'refuri' or 'refid' attribute"
+                )
+            docname, _, labelid = node["refuri"].partition("#")
+            uri = _doc_label(docname)
+            if labelid:
+                uri += f":{labelid}"
         else:
-            raise ExtensionError("<reference> requires 'refuri' or 'refid' attribute")
+            # Plain external hyperlink - nothing to namespace.
+            return super().visit_reference(node)
         return self.body.append(f"#link(<{uri}>)[")
+
+    def visit_target(self, node: nodes.target) -> None:
+        docname = _doc_label(self.curfilestack[-1])
+
+        if not node.get("ids") and node.get("refid"):
+            # PropagateTargets forwarded this target's id onto whatever
+            # followed it (section, paragraph, desc, ...), clearing our
+            # own ids. Walk past chained targets to find that node, like
+            # LaTeX's visit_target does.
+            next_node = node.next_node(ascend=True)
+            while isinstance(next_node, nodes.target):
+                next_node = next_node.next_node(ascend=True)
+
+            if isinstance(next_node, nodes.section):
+                # Already anchored by visit_title/depart_title's ids loop.
+                raise nodes.SkipNode
+
+            # Forwarded onto a node with no id-handling of its own (e.g. a
+            # paragraph, or a desc - depart_desc_signature only anchors the
+            # signature's own ids). Nothing else emits this, so do it here.
+            self._write_anchor(f"{docname}:{node['refid']}")
+            raise nodes.SkipNode
+
+        # A standalone target PropagateTargets left untouched (e.g. one at
+        # the end of a document) - anchor it directly, like ids[1:] above.
+        target_id = node["ids"][0] if node.get("ids") else None
+        if target_id:
+            self._write_anchor(f"{docname}:{target_id}")
+        raise nodes.SkipNode
 
     # Implements for Sphinx's nodes
     # =============================
+    def visit_pending_xref(self, node: addnodes.pending_xref):
+        # resolve_references() already replaced resolvable pending_xrefs
+        # with plain reference nodes; only unresolved ones reach here.
+        pass
+
+    def depart_pending_xref(self, node: addnodes.pending_xref):
+        pass
+
     def visit_desc(self, node: addnodes.desc):
         self.packages.add(_typst_local_package_fullname("atsphinx-typst"), "desc")
         self.body.append(f"{self._hi.prefix}#desc(\n")
@@ -127,10 +210,15 @@ class TypstTranslator(SphinxTranslator, BaseTypstTranslator):
         self._hi.push("  ")
 
     def depart_desc_signature(self, node: addnodes.desc_signature):
-        for id in node.get("ids", []):
-            self.body.append(f" <{id}>")
+        # Namespaced like section headings, see depart_title().
+        docname = _doc_label(self.curfilestack[-1])
+        ids = node.get("ids", [])
+        if ids:
+            self.body.append(f" <{docname}:{ids[0]}>")
         self._hi.pop()
         self.body.append(f"{self._hi.prefix}],\n")
+        for node_id in ids[1:]:
+            self._write_anchor(f"{docname}:{node_id}")
 
     def visit_desc_name(self, node: addnodes.desc_name):
         self.body.append(f"{self._hi.indent}#strong(delta: 400)[")
@@ -171,8 +259,15 @@ class TypstTranslator(SphinxTranslator, BaseTypstTranslator):
         pass
 
     def visit_start_of_file(self, node: addnodes.start_of_file):
-        # NOTE: Implement this when rendering anything as the "start of file."
-        pass
+        docname = node["docname"]
+        self.curfilestack.append(docname)
+        self._write_anchor(_doc_label(docname))
 
     def depart_start_of_file(self, node: addnodes.start_of_file):
-        pass
+        self.curfilestack.pop()
+
+    def _write_anchor(self, label: str) -> None:
+        # An invisible label not attached to any visible content - for
+        # document-level anchors and for ids that can't share a heading's
+        # own label (see depart_title()).
+        self.body.append(f"#metadata(none) <{label}>\n")

--- a/tests/test_e2e/test_it.py
+++ b/tests/test_e2e/test_it.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 import pytest
@@ -74,3 +75,201 @@ def test__copy_content_images(app: SphinxTestApp):
     assert (app.outdir / "index.typ").exists()
     assert (app.outdir / "_images/example.png").exists()
     assert (app.outdir / "_images/example.png").is_file()
+
+
+@pytest.mark.sphinx("typst", testroot="cross-references")
+def test__cross_references(app: SphinxTestApp):
+    """Test cross-referencing documents using :doc: role."""
+    app.build()
+    out = app.outdir / "index.typ"
+    assert out.exists()
+    content = out.read_text()
+    # Check that cross-reference content is present
+    assert "Cross-Reference Test Documentation" in content
+    # Verify that referenced pages are included in the main document
+    assert "Page 1" in content
+    assert "Page 2" in content
+    assert "Nested Page" in content
+    # Check that cross-references are converted to Typst links.
+    # A plain :doc: link carries no section anchor, so it points at the
+    # document-level label (see TypstTranslator._write_anchor()).
+    assert "#link(<page1>)" in content
+    assert "#link(<page2>)" in content
+    assert "#link(<subdir:nested>)" in content
+    assert "#link(<>)" not in content
+    # Verify that section labels are created for the first section of each document
+    assert "<page1:page-1>" in content
+    assert "<page2:page-2>" in content
+    assert "<subdir:nested:nested-page>" in content
+    # Verify content from referenced pages is included
+    assert "first page in our cross-reference test" in content
+    assert "second page in our cross-reference test" in content
+    assert "nested page in a subdirectory" in content
+    # Edge case: document without sections
+    assert "This document has no sections" in content
+    # Verify that a document-level label is generated for documents without sections
+    assert "#link(<no_sections>)" in content
+
+
+@pytest.mark.sphinx("typst", testroot="cross-references")
+def test__cross_references_ref_role_resolves_to_actual_target(app: SphinxTestApp):
+    """:ref: must resolve to the actual target, not be treated as a docname.
+
+    For ``:ref:`custom-target``` the target is the explicit
+    ``.. _custom-target:`` label in page2.rst, which is a distinct id from
+    the section's own auto-generated ``target-section`` id - :ref: must
+    resolve to the former, and that label must actually exist in the
+    output.
+    """
+    app.build()
+    content = (app.outdir / "index.typ").read_text()
+    assert "#link(<page2:custom-target>)" in content
+    assert content.count("<page2:custom-target>") >= 2
+
+
+@pytest.mark.sphinx("typst", testroot="cross-references")
+def test__cross_references_bare_relative_doc_path(app: SphinxTestApp):
+    """A bare relative :doc: target resolves to the current doc's directory.
+
+    Per Sphinx docs: ":doc:`parrot` occurring in sketches/index links to
+    sketches/parrot" - i.e. no ``../``/``./`` prefix is needed.
+    ``subdir/nested.rst`` references ``:doc:`sibling``` with no prefix, so
+    it must resolve to ``subdir/sibling``, not a top-level ``sibling``
+    document.
+    """
+    app.build()
+    content = (app.outdir / "index.typ").read_text()
+    assert "#link(<subdir:sibling>)" in content
+    assert "Sibling Page" in content
+
+
+@pytest.mark.sphinx("typst", testroot="cross-references")
+def test__cross_references_no_sections_label_is_actually_defined(app: SphinxTestApp):
+    """A no-sections document must not link to a label that's never emitted.
+
+    ``no_sections.rst`` has no headings, so it never gets a section label.
+    A whole-document ``:doc:`` reference to it must still resolve to some
+    label that is actually defined in the output (the document-level
+    anchor), not a dangling reference.
+    """
+    app.build()
+    content = (app.outdir / "index.typ").read_text()
+    assert "#link(<no_sections>)" in content
+    # One occurrence is the `#link(<no_sections>)` reference itself; a
+    # second, independent occurrence must exist as the actual label
+    # definition it points to.
+    assert content.count("<no_sections>") >= 2
+
+
+@pytest.mark.sphinx("typst", testroot="cross-references")
+def test__cross_references_implicit_title_uses_document_title(app: SphinxTestApp):
+    """Implicit-title :doc: must use the target document's title as link text.
+
+    Per Sphinx docs: "If no explicit link text is given... the link caption
+    will be the title of the given document."
+    """
+    app.build()
+    content = (app.outdir / "index.typ").read_text()
+    assert "#link(<page1>)[Page 1]" in content
+    assert "#link(<page2>)[Page 2]" in content
+
+
+@pytest.mark.sphinx("typst", testroot="cross-references")
+def test__cross_references_labels_use_valid_typst_syntax(app: SphinxTestApp):
+    """Every generated label must only use characters Typst's <label> syntax allows.
+
+    Per Typst's docs, a label's name may only contain letters, numbers, ``_``,
+    ``-``, ``:`` and ``.``. ``:confval:`my_option[]``` has a reftarget
+    containing ``[``/``]`` (mirroring this project's own real
+    ``typst_documents[].entrypoint`` confval), which is copied verbatim into
+    the generated label and breaks the Typst parser ("unclosed label").
+    """
+    app.build()
+    content = (app.outdir / "index.typ").read_text()
+    label_pattern = re.compile(r"<([^<>\s]+)>")
+    valid_label = re.compile(r"^[A-Za-z0-9_.:-]+$")
+    invalid = [m for m in label_pattern.findall(content) if not valid_label.match(m)]
+    assert invalid == []
+
+
+@pytest.mark.sphinx("typst", testroot="cross-references")
+def test__cross_references_label_before_paragraph_gets_anchor(app: SphinxTestApp):
+    """An explicit label directly before a plain paragraph must not be dropped.
+
+    ``PropagateTargets`` merges ``.. _label-before-paragraph:`` into the
+    following paragraph the same way it merges a label into a following
+    section (``ids=[]``, ``refid`` set on the target). Unlike a section,
+    a plain paragraph has no id-emitting logic of its own in this writer,
+    so nothing else will emit this anchor - ``visit_target`` must recognize
+    that and write it directly instead of assuming it is "handled
+    elsewhere".
+    """
+    app.build()
+    content = (app.outdir / "index.typ").read_text()
+    assert "#metadata(none) <index:label-before-paragraph>" in content
+
+
+@pytest.mark.sphinx("typst", testroot="cross-references")
+def test__cross_references_label_before_confval_gets_anchor(app: SphinxTestApp):
+    """An explicit label directly before a ``desc`` node must not be dropped.
+
+    ``.. _label-before-confval:`` immediately precedes a ``.. confval::``
+    directive. ``PropagateTargets`` merges the label onto the parent
+    ``desc`` node, not onto its ``desc_signature`` child, so it is a
+    distinct id from the confval's own auto-generated
+    ``confval-labelled_option`` id. ``depart_desc_signature`` only emits
+    anchors for the signature's own ids, so this one needs its own anchor
+    from ``visit_target``.
+    """
+    app.build()
+    content = (app.outdir / "index.typ").read_text()
+    assert "#metadata(none) <index:label-before-confval>" in content
+    assert "<index:confval-labelled_option>" in content
+
+
+@pytest.mark.sphinx("typst", testroot="cross-references")
+def test__cross_references_same_page_refid_link_is_namespaced(app: SphinxTestApp):
+    """A plain RST ``title_`` link must produce a namespaced Typst anchor.
+
+    A same-page reference written as `` `Section Title`_ `` in RST (or an
+    equivalent ``#anchor`` link in MyST) resolves to a ``reference`` node
+    with ``refid='anchor-id'`` but with the ``internal`` attribute *absent*
+    (not set to ``True``).  The base rst2typst writer handles this by
+    emitting ``#link(<anchor-id>)`` without any namespace, which fails at
+    Typst compile time when all documents are merged into one file.
+    ``visit_reference`` must namespace the label even when ``internal`` is
+    not set.
+    """
+    app.build()
+    content = (app.outdir / "index.typ").read_text()
+    # The link must carry the document namespace, not a bare anchor.
+    assert "#link(<page1:anchor-target>)" in content
+    # The label definition it points to must also exist in the output.
+    assert content.count("<page1:anchor-target>") >= 2
+
+
+@pytest.mark.sphinx("typst", testroot="cross-references")
+def test__cross_references_external_hyperlink_is_not_namespaced(app: SphinxTestApp):
+    """A genuine external hyperlink must render as a plain, un-namespaced link.
+
+    Unlike RST `Title`_ same-page anchors, a real external hyperlink (e.g.
+    `` `Example <https://...>`_ ``) has neither ``internal`` nor ``refid``
+    set - only ``refuri`` pointing at an actual URL. ``visit_reference``
+    must let this fall through to the base rst2typst writer unchanged,
+    rather than trying to treat the URL as a docname to namespace.
+    """
+    app.build()
+    content = (app.outdir / "index.typ").read_text()
+    assert '#link("https://example.com/")[' in content
+
+
+@pytest.mark.sphinx("typstpdf", testroot="cross-references")
+def test__cross_references_pdf_compiles(app: SphinxTestApp):
+    """The merged document with cross-references must still compile to PDF.
+
+    Combines several of the issues above (dangling labels, label characters
+    Typst rejects) into one end-to-end check that the generated Typst source
+    is actually valid.
+    """
+    app.build()
+    assert (app.outdir / "index.pdf").exists()

--- a/tests/testdocs/test-cross-references/conf.py
+++ b/tests/testdocs/test-cross-references/conf.py
@@ -1,0 +1,14 @@
+# noqa: D100
+
+extensions = [
+    "atsphinx.typst",
+]
+
+typst_documents = [
+    {
+        "entrypoint": "index",
+        "filename": "index",
+        "theme": "manual",
+        "title": "Cross-Reference Test Documentation",
+    }
+]

--- a/tests/testdocs/test-cross-references/index.rst
+++ b/tests/testdocs/test-cross-references/index.rst
@@ -1,0 +1,76 @@
+Cross-Reference Test Documentation
+===================================
+
+This document tests cross-referencing to other documents as described in the Sphinx documentation.
+
+Cross-Referencing Documents
+---------------------------
+
+Using the ``:doc:`` role to reference other documents:
+
+* Link to page1: :doc:`page1`
+* Link to page2: :doc:`page2`
+* Link to page1 with custom text: :doc:`First Page <page1>`
+* Link to page2 with custom text: :doc:`Second Page <page2>`
+
+Using absolute paths:
+
+* Absolute link to page1: :doc:`/page1`
+* Absolute link to page2: :doc:`/page2`
+
+Using relative paths with subdirectories:
+
+* Link to nested page: :doc:`subdir/nested`
+
+Cross-Referencing with Download Role
+-------------------------------------
+
+The ``:download:`` role can also reference documents:
+
+* Download link: :download:`page1.rst <page1.rst>`
+
+Other Reference Roles
+----------------------
+
+Sphinx resolves more than just ``:doc:`` through ``pending_xref`` nodes.
+These should keep working the same way they do without the Typst builder:
+
+* Ref to a named target in another document: :ref:`custom-target`
+* Confval-style target containing brackets: :confval:`my_option[]`
+* A genuine external hyperlink, not resolved by Sphinx at all: `Example <https://example.com/>`_
+
+.. confval:: my_option[]
+
+   A configuration value whose name contains brackets, like the real
+   ``typst_documents[].entrypoint`` confval used in this project's own docs.
+
+.. _label-before-confval:
+
+.. confval:: labelled_option
+
+   A confval preceded by its own explicit label, distinct from the
+   confval's own auto-generated id.
+
+.. _label-before-paragraph:
+
+An explicit label placed directly before a plain paragraph (not a heading
+or a directive with its own signature).
+
+Edge Cases
+----------
+
+Testing edge cases:
+
+* Reference to document without sections: :doc:`no_sections`
+
+Table of Contents
+-----------------
+
+.. toctree::
+   :maxdepth: 2
+
+   page1
+   page2
+   subdir/nested
+   subdir/sibling
+   no_sections

--- a/tests/testdocs/test-cross-references/no_sections.rst
+++ b/tests/testdocs/test-cross-references/no_sections.rst
@@ -1,0 +1,5 @@
+This document has no sections, only paragraphs.
+
+It contains some text but no section headings with IDs.
+
+This tests the fallback behavior when a document has no sections.

--- a/tests/testdocs/test-cross-references/page1.rst
+++ b/tests/testdocs/test-cross-references/page1.rst
@@ -1,0 +1,26 @@
+Page 1
+======
+
+This is the first page in our cross-reference test.
+
+.. _explicit-page1-label:
+
+Content
+-------
+
+This page contains some content that can be referenced from other documents.
+
+See the `Anchor Target`_ section for more details.
+
+Anchor Target
+-------------
+
+A section referenced via a plain RST ``title_`` link (``refid`` set,
+``internal`` attribute absent) to exercise same-page anchor links.
+
+Back to Main Content
+--------------------
+
+You can go back to the main document.
+
+Or navigate to :doc:`page2`.

--- a/tests/testdocs/test-cross-references/page2.rst
+++ b/tests/testdocs/test-cross-references/page2.rst
@@ -1,0 +1,23 @@
+Page 2
+======
+
+This is the second page in our cross-reference test.
+
+More Content
+------------
+
+This page also contains content that can be referenced.
+
+Navigation
+----------
+
+* Back to the main document
+* Go to :doc:`page1`
+* Visit the :doc:`nested page <subdir/nested>`
+
+.. _custom-target:
+
+Target Section
+--------------
+
+This section is the target of a ``:ref:`` from the main document.

--- a/tests/testdocs/test-cross-references/subdir/nested.rst
+++ b/tests/testdocs/test-cross-references/subdir/nested.rst
@@ -1,0 +1,26 @@
+Nested Page
+===========
+
+This is a nested page in a subdirectory.
+
+Nested Content
+--------------
+
+This page demonstrates cross-referencing from a subdirectory.
+
+Navigation from Subdirectory
+-----------------------------
+
+* Back to the main document
+* Go to :doc:`../page1`
+* Go to :doc:`../page2`
+
+Using absolute paths:
+
+* Absolute link to page1: :doc:`/page1`
+
+Using a bare relative path (no ``../`` or ``./`` prefix), which per Sphinx
+docs resolves relative to this document's own directory, i.e. to
+``subdir/sibling``:
+
+* Bare relative link to sibling: :doc:`sibling`

--- a/tests/testdocs/test-cross-references/subdir/sibling.rst
+++ b/tests/testdocs/test-cross-references/subdir/sibling.rst
@@ -1,0 +1,7 @@
+Sibling Page
+============
+
+This page lives next to ``nested.rst`` in the same subdirectory.
+
+It is the target of a bare relative ``:doc:`` reference (no ``../`` or
+``./`` prefix) from ``nested.rst``.


### PR DESCRIPTION
Implement :doc:/:ref:/:confval:/etc. cross-references in the Typst
builder, following the same approach as Sphinx's LaTeX builder: all
documents are merged into a single doctree, and Sphinx's standard
env.resolve_references() runs against that merged tree right after
merging. This lets Sphinx's own domains handle path normalization,
label lookup, title substitution, and intersphinx exactly as they do
for any other builder.

Builder.get_target_uri()/get_relative_uri() map a docname onto the
single merged Typst document, mirroring the LaTeX builder's
"%docname" convention. The writer's job is then only to translate the
refid/refuri that Sphinx resolves into a namespaced Typst label
(<docname:id>); the namespace keeps ids from colliding across
documents now that they all share one output file. A small
per-document "#metadata(none) <label>" anchor - the same trick HTML
uses for an extra empty anchor per additional id on an element - gives
whole-document :doc: references something to link to even when the
target document has no sections, and covers section/signature ids
beyond the first, since Typst only allows one label per element.

docutils' PropagateTargets transform forwards an explicit label (e.g.
RST's ``.. _label:``) placed directly before a section, a paragraph,
a directive with a signature (``.. confval::``), or another target,
onto whatever follows it: it clears the target node's own ids and
points its refid at the merged-in id instead. visit_target mirrors
Sphinx's LaTeX writer (visit_target in sphinx/writers/latex.py) to
handle this correctly: walk past any chain of adjacent forwarding
targets to find what the id actually landed on. When that's a
section, visit_title/depart_title already emit a namespaced anchor
for every one of the section's ids (including ones forwarded here), so
visit_target skips it to avoid emitting the label twice. Anything else - a plain paragraph, or a ``desc`` node whose own id handling in
depart_desc_signature only looks at its signature's ids, not ids
forwarded onto the parent ``desc`` - has no other code path that would
emit the anchor, so visit_target writes it directly.

Includes test coverage for basic cross-references, :ref: to named
targets, relative paths (including bare relative paths resolved from
the referring document's directory), nested documents, edge cases such
as documents without sections and confval-style targets, and explicit
labels placed directly before a plain paragraph or a confval directive.